### PR TITLE
Adds hardcoded storage folder path for AI

### DIFF
--- a/API/DoorRequest.API/Dockerfile
+++ b/API/DoorRequest.API/Dockerfile
@@ -16,4 +16,5 @@ RUN dotnet publish "DoorRequest.API.csproj" -c Release -o /app/publish
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
+RUN mkdir logging
 ENTRYPOINT ["dotnet", "DoorRequest.API.dll"]

--- a/API/DoorRequest.API/Startup.cs
+++ b/API/DoorRequest.API/Startup.cs
@@ -3,6 +3,8 @@ using AspNetCore.Totp.Interface;
 using DoorRequest.API.Config;
 using DoorRequest.API.Services;
 using IdentityServer4.AccessTokenValidation;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
@@ -31,6 +33,8 @@ namespace DoorRequest.API
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddSingleton(typeof(ITelemetryChannel),
+                new ServerTelemetryChannel() { StorageFolder = "/logging" });
             services.AddApplicationInsightsTelemetry();
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
             var identityConfiguration = 


### PR DESCRIPTION
Fixes the `AI: Local storage access has resulted in an error (User: ) (CustomFolder: ). If you want Application Insights SDK to store telemetry locally on disk in case of transient network issues please give the…` bug